### PR TITLE
12 - Add nullable service_id attribute to Category CreateParams

### DIFF
--- a/src/Data/CreateParams.php
+++ b/src/Data/CreateParams.php
@@ -17,6 +17,7 @@ use Upmind\ProvisionBase\Provider\DataSet\Rules;
  * @property-read string $package_identifier Service package identifier, if any
  * @property-read string[]|null $promo_codes Optional array of promo codes applied to the order
  * @property-read mixed[]|null $extra Any extra data to pass to the service endpoint
+ * @property-read string|null $service_id The Product/Service ID in the system
  */
 class CreateParams extends DataSet
 {
@@ -33,6 +34,7 @@ class CreateParams extends DataSet
             'promo_codes' => ['nullable', 'array'],
             'promo_codes.*' => ['string'],
             'extra' => ['nullable', 'array'],
+            'service_id' => ['nullable', 'string'],
         ]);
     }
 }

--- a/src/Providers/RankingCoach/Provider.php
+++ b/src/Providers/RankingCoach/Provider.php
@@ -62,8 +62,10 @@ class Provider extends Category implements ProviderInterface
                 $this->errorResult('Customer email only allows for alphanumeric characters!');
             }
 
+            $customerId = $params->service_id ?? (string) $params->customer_id;
+
             $this->api()->createAccount(
-                (string) $params->customer_id,
+                $customerId,
                 $params->customer_email,
                 $params->customer_name,
                 $params->domain,
@@ -71,7 +73,7 @@ class Provider extends Category implements ProviderInterface
             );
 
             return CreateResult::create()
-                ->setUsername((string) $params->customer_id)
+                ->setUsername($customerId)
                 ->setDomain($params->domain)
                 ->setPackageIdentifier($params->package_identifier)
                 ->setMessage('Account created');

--- a/src/Providers/RankingCoach/Provider.php
+++ b/src/Providers/RankingCoach/Provider.php
@@ -62,7 +62,7 @@ class Provider extends Category implements ProviderInterface
                 $this->errorResult('Customer email only allows for alphanumeric characters!');
             }
 
-            $customerId = $params->service_id ?? (string) $params->customer_id;
+            $customerId = (string)($params->service_id ?: $params->customer_id);
 
             $this->api()->createAccount(
                 $customerId,


### PR DESCRIPTION
Closes #12 

- Add new `service_id` param in Create Params.
- Use new `service_id` attribute with Ranking Coach when creating account. Takes precedence over `customer_id` if exists.